### PR TITLE
MNT: Add run export for Rivet

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -63,7 +63,7 @@ if [[ "${OSX_SDK_DIR:-}" == "" ]]; then
     /usr/bin/sudo chown "${USER}" "${OSX_SDK_DIR}"
   fi
 else
-  if tmpf=$(mktemp -p "$OSX_SDK_DIR" tmp.XXXXXXXX 2>/dev/null); then
+  if tmpf=$(mktemp "$OSX_SDK_DIR"/tmp.XXXXXXXX 2>/dev/null); then
       rm -f "$tmpf"
       echo "OSX_SDK_DIR is writeable without sudo, continuing"
   else

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "rivet-feedstock"
-version = "3.62.0"  # conda-smithy version used to generate this file
+version = "2026.5.29"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/rivet-feedstock"
 authors = ["@conda-forge/rivet"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,19 +21,21 @@ source:
     - 0008-fix-Skip-Python-import-tests-when-building-in-conda.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
 
 requirements:
+  run_exports:
+    - ${{ pin_subpackage("rivet", upper_bound="x.x") }}
   build:
     - if: build_platform != target_platform
       then:
         - python
         - cross-python_${{ target_platform }}
         - cython
-    - ${{ stdlib('c') }}
-    - ${{ compiler('cxx') }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler("cxx") }}
     - automake
     - libtool
     - make
@@ -53,8 +55,6 @@ requirements:
     - zlib
   run:
     - python
-    # This can be removed when run_exports is added to yoda
-    - ${{ pin_compatible('yoda', upper_bound='x.x') }}
     - matplotlib-base
     - requests
 
@@ -77,7 +77,7 @@ tests:
         - rivet-mkhtml-tex
         - rivet-mkvaldir
       lib:
-        - libRivet
+        - Rivet
       include:
         - Rivet/**/*
       site_packages:
@@ -114,7 +114,7 @@ tests:
 
   - requirements:
       run:
-        - ${{ compiler('cxx') }}
+        - ${{ compiler("cxx") }}
         - hepmc3
         - zlib
     files:


### PR DESCRIPTION
* Add minor level (`x.x`) run export for Rivet as Rivet distributes a dynamically linked library, `libRivet`.
* Remove `pin_compatible` for YODA as the [YODA feedstock now has run exports](https://github.com/conda-forge/yoda-feedstock/blob/5fecf047339ee46d9beb141d0325dcd3598e878e/recipe/recipe.yaml#L23-L24).
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
